### PR TITLE
Update dependencies and documentation.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -154,3 +154,8 @@ jobs:
         with:
           command: run
           args: --example long_expr_context --release
+
+      - uses: actions-rs/cargo@v1
+        with:
+          command: run
+          args: --example codespan --release --features codespan

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,13 +1,30 @@
 # Changelog
 
+## 0.3.0 (2021-04-20)
+
+### Added
+
+* `"codespan"` feature to re-export [`codespan`] \(disabled by default\). ([#15])
+
+### Changed
+
+* Update [`codespan-reporting`] version from `0.11.0` to `0.11.1`. ([#15])
+* Update documentation in `README.md` and `lib.rs`. ([#15])
+
+[`codespan`]: https://docs.rs/codespan
+
+[#15]: https://github.com/azriel91/srcerr/pull/15
+
 ## 0.2.0 (2021-02-03)
 
 ### Changed
 
-* Removed all formatting logic, and back onto `codespan-reporting`. ([#11], [#12])
+* Removed all formatting logic, and back onto [`codespan-reporting`]. ([#11], [#12])
 
 [#11]: https://github.com/azriel91/srcerr/issues/11
 [#12]: https://github.com/azriel91/srcerr/pull/12
+
+[`codespan-reporting`]: https://docs.rs/codespan-reporting
 
 ## 0.1.0 (2020-11-20)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,7 +11,10 @@ keywords = ["error", "format"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
-codespan-reporting = "0.11.0"
+codespan-reporting = "0.11.1"
+
+[dev-dependencies]
+codespan = "0.11.1"
 
 [features]
 serialization = ["codespan-reporting/serialization"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srcerr"
-version = "0.2.1"
+version = "0.3.0"
 authors = ["Azriel Hoh <azriel91@gmail.com>"]
 edition = "2018"
 description = "User friendly errors from source data."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,9 @@ readme = "README.md"
 keywords = ["error", "format"]
 license = "MIT OR Apache-2.0"
 
+[package.metadata.docs.rs]
+features = ["codespan"]
+
 [dependencies]
 codespan = { version = "0.11.1", optional = true }
 codespan-reporting = "0.11.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "srcerr"
-version = "0.2.0"
+version = "0.2.1"
 authors = ["Azriel Hoh <azriel91@gmail.com>"]
 edition = "2018"
 description = "User friendly errors from source data."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,10 +11,12 @@ keywords = ["error", "format"]
 license = "MIT OR Apache-2.0"
 
 [dependencies]
+codespan = { version = "0.11.1", optional = true }
 codespan-reporting = "0.11.1"
-
-[dev-dependencies]
-codespan = "0.11.1"
 
 [features]
 serialization = ["codespan-reporting/serialization"]
+
+[[example]]
+name = "codespan"
+required-features = ["codespan"]

--- a/README.md
+++ b/README.md
@@ -12,6 +12,16 @@ This library provies a [`SourceError`] struct that holds:
 * [`ErrorDetail`]: Enum with matching variants to `ErrorCode`, but each variant contains information specific to an instance of the error.
 * [`Severity`]: The severity to report the error.
 
+This library backs onto [`codespan-reporting`] to render diagnostic errors.
+
+The `"codespan"` feature can also be used to expose [`codespan`] types:
+
+```toml
+srcerr = { version = "0.3.0", features = ["codespan"] }
+```
+
+[`codespan-reporting`]: https://docs.rs/codespan-reporting
+[`codespan`]: https://docs.rs/codespan
 [`ErrorCode`]: https://docs.rs/srcerr/latest/srcerr/trait.ErrorCode.html
 [`ErrorDetail`]: https://docs.rs/srcerr/latest/srcerr/trait.ErrorDetail.html
 [`Severity`]: https://docs.rs/codespan-reporting/0.11.1/codespan_reporting/diagnostic/enum.Severity.html
@@ -193,6 +203,7 @@ cargo run --example simple
 cargo run --example source_ref_hint
 cargo run --example long_expr_context
 cargo run --example html > /tmp/index.html
+cargo run --example codespan --features codespan
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -4,49 +4,187 @@
 ![CI](https://github.com/azriel91/srcerr/workflows/CI/badge.svg)
 [![Coverage Status](https://codecov.io/gh/azriel91/srcerr/branch/main/graph/badge.svg)](https://codecov.io/gh/azriel91/srcerr)
 
-User friendly errors from source data.
+Types to track error codes and details.
 
-This crate provides a `SourceError` type, which is formatted like Rust's compiler errors. Consumers are responsible for providing the correct byte and character indices, and line and column numbers.
+This library provies a [`SourceError`] struct that holds:
 
-Color support is enabled by default.
+* [`ErrorCode`]: Enum whose variants indicate error code, simple description.
+* [`ErrorDetail`]: Enum with matching variants to `ErrorCode`, but each variant contains information specific to an instance of the error.
+* [`Severity`]: The severity to report the error.
 
-## Demo
-
-### Suggestions
-
-```rust
-error[E1]: `chosen` value `ghi` is invalid.
-  --> examples/source_ref_hint.yaml:6:9
-   |
- 6 | chosen: "ghi"
-   |         ^^^^^
-   = note: expected one of: `abc`, `def`
-
-help: `chosen` value must come from one of `available` values:
-  --> examples/source_ref_hint.yaml:2:1
-   |
- 2 | available:
-   | ---------- hint: first defined here
- 3 |   - "abc"
- 4 |   - "def"
-   |
-```
-
-### Long Expressions
-
-```rust
-error[E1]: Value `150` is invalid.
-  --> /mnt/data/work/github/azriel91/srcerr/examples/long_expr_context.json:1:101
-   |
- 1 | .. "p":150, ..
-   |        ^^^
-   |        |
-   |        101
-   |
-   = hint: expected value to be less than 26
-```
+[`ErrorCode`]: https://docs.rs/srcerr/latest/srcerr/trait.ErrorCode.html
+[`ErrorDetail`]: https://docs.rs/srcerr/latest/srcerr/trait.ErrorDetail.html
+[`Severity`]: https://docs.rs/codespan-reporting/0.11.1/codespan_reporting/diagnostic/enum.Severity.html
+[`SourceError`]: https://docs.rs/srcerr/latest/srcerr/struct.SourceError.html
 
 ## Usage
+
+<details>
+<summary>1. Implement ErrorCode</summary>
+
+```rust
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SimpleErrorCode {
+    /// Error when a value is out of range.
+    ValueOutOfRange,
+    /// Error when a string is too long.
+    StringTooLong,
+}
+
+impl ErrorCode for SimpleErrorCode {
+    const ERROR_CODE_MAX: usize = 2;
+    const PREFIX: &'static str = "E";
+
+    fn code(self) -> usize {
+        match self {
+            Self::ValueOutOfRange => 1,
+            Self::StringTooLong => 2,
+        }
+    }
+
+    fn description(self) -> &'static str {
+        match self {
+            Self::ValueOutOfRange => "Value out of range.",
+            Self::StringTooLong => "String provided is too long.",
+        }
+    }
+}
+```
+
+</details>
+
+<details>
+<summary>2. Implement ErrorDetail</summary>
+
+```rust
+#[derive(Debug)]
+pub enum SimpleErrorDetail {
+    /// Error when a value is out of range.
+    ValueOutOfRange {
+        /// ID of the file containing the invalid value.
+        file_id: usize,
+        /// The value.
+        value: i32,
+        /// Byte begin and end indices where the value is defined.
+        value_byte_indices: Range<usize>,
+        /// Range that the value must be within.
+        range: RangeInclusive<u32>,
+    },
+    /// Error when a string is too long.
+    StringTooLong {
+        /// ID of the file containing the invalid value.
+        file_id: usize,
+        /// The value that is too long.
+        value: String,
+        /// Byte begin and end indices where the value is defined.
+        value_byte_indices: Range<usize>,
+        /// Maximum length allowed for the string.
+        limit: usize,
+    },
+}
+
+impl<'files> ErrorDetail<'files> for SimpleErrorDetail {
+    type Files = SimpleFiles<&'files str, &'files str>;
+
+    fn labels(&self) -> Vec<Label<usize>> {
+        match self {
+            Self::ValueOutOfRange {
+                file_id,
+                value_byte_indices,
+                range,
+                ..
+            } => {
+                vec![
+                    Label::primary(*file_id, value_byte_indices.clone()).with_message(format!(
+                        "not within the range: `{}..={}`",
+                        range.start(),
+                        range.end()
+                    )),
+                ]
+            }
+            Self::StringTooLong {
+                file_id,
+                value_byte_indices,
+                limit,
+                ..
+            } => {
+                vec![
+                    Label::primary(*file_id, value_byte_indices.clone())
+                        .with_message(format!("exceeds the {} character limit.", limit)),
+                ]
+            }
+        }
+    }
+
+    fn notes(&self, _files: &Self::Files) -> Vec<String> {
+        match self {
+            Self::ValueOutOfRange { range, .. } => {
+                let valid_exprs = range.clone().map(|n| Cow::Owned(n.to_string()));
+                let suggestion = Note::valid_exprs(valid_exprs).expect("Failed to format note.");
+                vec![suggestion]
+            }
+            Self::StringTooLong { .. } => vec![],
+        }
+    }
+}
+```
+
+</details>
+
+<details>
+<summary>3. Construct SourceError when there is an error.</summary>
+
+```rust
+fn value_out_of_range<'f>(
+    file_id: usize,
+) -> SourceError<'f, SimpleErrorCode, SimpleErrorDetail, SimpleFiles<&'f str, &'f str>> {
+    let error_code = SimpleErrorCode::ValueOutOfRange;
+    let error_detail = SimpleErrorDetail::ValueOutOfRange {
+        file_id,
+        value: -1,
+        value_byte_indices: 21..23,
+        range: 1..=3,
+    };
+    let severity = Severity::Error;
+
+    SourceError::new(error_code, error_detail, severity)
+}
+
+fn string_too_long<'f>(
+    file_id: usize,
+    content: &str,
+) -> SourceError<'f, SimpleErrorCode, SimpleErrorDetail, SimpleFiles<&'f str, &'f str>> {
+    let error_code = SimpleErrorCode::StringTooLong;
+    let error_detail = SimpleErrorDetail::StringTooLong {
+        file_id,
+        value: content[40..47].to_string(),
+        value_byte_indices: 39..48,
+        limit: 5,
+    };
+    let severity = Severity::Error;
+
+    SourceError::new(error_code, error_detail, severity)
+}
+```
+
+</details>
+
+<details>
+<summary>4. Output the diagnostic message.</summary>
+
+```rust
+let value_out_of_range = value_out_of_range(file_id);
+let value_out_of_range = value_out_of_range.as_diagnostic(&files);
+let string_too_long = string_too_long(file_id, content);
+let string_too_long = string_too_long.as_diagnostic(&files);
+
+let writer = StandardStream::stderr(ColorChoice::Always);
+let config = term::Config::default();
+term::emit(&mut writer.lock(), &config, &files, &value_out_of_range)?;
+term::emit(&mut writer.lock(), &config, &files, &string_too_long)?;
+```
+
+</details>
 
 Sample usage can be seen in the [examples](examples).
 

--- a/examples/codespan.rs
+++ b/examples/codespan.rs
@@ -1,7 +1,7 @@
 use std::{borrow::Cow, ops::RangeInclusive, path::Path};
 
-use codespan::{FileId, Files, Span};
 use srcerr::{
+    codespan::{FileId, Files, Span},
     codespan_reporting::{
         diagnostic::{Label, Severity},
         files::Error,

--- a/examples/codespan.rs
+++ b/examples/codespan.rs
@@ -1,0 +1,170 @@
+use std::{borrow::Cow, ops::RangeInclusive, path::Path};
+
+use codespan::{FileId, Files, Span};
+use srcerr::{
+    codespan_reporting::{
+        diagnostic::{Label, Severity},
+        files::Error,
+        term,
+        term::termcolor::{ColorChoice, StandardStream},
+    },
+    fmt::Note,
+    ErrorCode, ErrorDetail, SourceError,
+};
+
+const SIMPLE_TOML: &str = include_str!("simple.toml");
+
+fn main() -> Result<(), Error> {
+    // Path to file containing error.
+    let path = Path::new("examples/simple.toml");
+    // Content from the file.
+    let content = SIMPLE_TOML;
+
+    let mut files = Files::<Cow<'_, str>>::new();
+    let path_display = path.display().to_string();
+    let file_id = files.add(path_display.as_str(), Cow::Borrowed(content));
+    let content = files.source(file_id);
+
+    let value_out_of_range = value_out_of_range(file_id);
+    let value_out_of_range = value_out_of_range.as_diagnostic(&files);
+    let string_too_long = string_too_long(file_id, content);
+    let string_too_long = string_too_long.as_diagnostic(&files);
+
+    let writer = StandardStream::stderr(ColorChoice::Always);
+    let config = term::Config::default();
+    term::emit(&mut writer.lock(), &config, &files, &value_out_of_range)?;
+    term::emit(&mut writer.lock(), &config, &files, &string_too_long)?;
+
+    Ok(())
+}
+
+fn value_out_of_range<'f>(
+    file_id: FileId,
+) -> SourceError<'f, SimpleErrorCode, SimpleErrorDetail, Files<Cow<'f, str>>> {
+    let error_code = SimpleErrorCode::ValueOutOfRange;
+    let error_detail = SimpleErrorDetail::ValueOutOfRange {
+        file_id,
+        value: -1,
+        value_byte_indices: Span::from(21..23),
+        range: 1..=3,
+    };
+    let severity = Severity::Error;
+
+    SourceError::new(error_code, error_detail, severity)
+}
+
+fn string_too_long<'f>(
+    file_id: FileId,
+    content: &str,
+) -> SourceError<'f, SimpleErrorCode, SimpleErrorDetail, Files<Cow<'f, str>>> {
+    let error_code = SimpleErrorCode::StringTooLong;
+    let error_detail = SimpleErrorDetail::StringTooLong {
+        file_id,
+        value: content[40..47].to_string(),
+        value_byte_indices: Span::from(39..48),
+        limit: 5,
+    };
+    let severity = Severity::Error;
+
+    SourceError::new(error_code, error_detail, severity)
+}
+
+/// Error codes for simple example.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum SimpleErrorCode {
+    /// Error when a value is out of range.
+    ValueOutOfRange,
+    /// Error when a string is too long.
+    StringTooLong,
+}
+
+impl ErrorCode for SimpleErrorCode {
+    const ERROR_CODE_MAX: usize = 2;
+    const PREFIX: &'static str = "E";
+
+    fn code(self) -> usize {
+        match self {
+            Self::ValueOutOfRange => 1,
+            Self::StringTooLong => 2,
+        }
+    }
+
+    fn description(self) -> &'static str {
+        match self {
+            Self::ValueOutOfRange => "Value out of range.",
+            Self::StringTooLong => "String provided is too long.",
+        }
+    }
+}
+
+/// Error detail for simple example.
+#[derive(Debug)]
+pub enum SimpleErrorDetail {
+    /// Error when a value is out of range.
+    ValueOutOfRange {
+        /// ID of the file containing the invalid value.
+        file_id: FileId,
+        /// The value.
+        value: i32,
+        /// Byte begin and end indices where the value is defined.
+        value_byte_indices: Span,
+        /// Range that the value must be within.
+        range: RangeInclusive<u32>,
+    },
+    /// Error when a string is too long.
+    StringTooLong {
+        /// ID of the file containing the invalid value.
+        file_id: FileId,
+        /// The value that is too long.
+        value: String,
+        /// Byte begin and end indices where the value is defined.
+        value_byte_indices: Span,
+        /// Maximum length allowed for the string.
+        limit: usize,
+    },
+}
+
+impl<'files> ErrorDetail<'files> for SimpleErrorDetail {
+    type Files = Files<Cow<'files, str>>;
+
+    fn labels(&self) -> Vec<Label<FileId>> {
+        match self {
+            Self::ValueOutOfRange {
+                file_id,
+                value_byte_indices,
+                range,
+                ..
+            } => {
+                vec![
+                    Label::primary(*file_id, value_byte_indices.clone()).with_message(format!(
+                        "not within the range: `{}..={}`",
+                        range.start(),
+                        range.end()
+                    )),
+                ]
+            }
+            Self::StringTooLong {
+                file_id,
+                value_byte_indices,
+                limit,
+                ..
+            } => {
+                vec![
+                    Label::primary(*file_id, value_byte_indices.clone())
+                        .with_message(format!("exceeds the {} character limit.", limit)),
+                ]
+            }
+        }
+    }
+
+    fn notes(&self, _files: &Self::Files) -> Vec<String> {
+        match self {
+            Self::ValueOutOfRange { range, .. } => {
+                let valid_exprs = range.clone().map(|n| Cow::Owned(n.to_string()));
+                let suggestion = Note::valid_exprs(valid_exprs).expect("Failed to format note.");
+                vec![suggestion]
+            }
+            Self::StringTooLong { .. } => vec![],
+        }
+    }
+}

--- a/src/fmt/code.rs
+++ b/src/fmt/code.rs
@@ -28,7 +28,7 @@ where
 
     /// Writes the error code into the buffer.
     ///
-    /// See [`Self::error_code`] for a version that allocates a `String`.
+    /// See [`Self::string`] for a version that allocates a `String`.
     ///
     /// # Parameters
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,22 @@
 #![deny(missing_docs, missing_debug_implementations)]
 
-//! User friendly errors from source data.
+//! Types to track error codes and details.
+//!
+//! This library provies a [`SourceError`] struct that holds:
+//!
+//! * [`ErrorCode`]: Enum whose variants indicate error code, simple
+//!   description.
+//! * [`ErrorDetail`]: Enum with matching variants to `ErrorCode`, but each
+//!   variant contains information specific to an instance of the error.
+//! * [`Severity`]: The severity to report the error.
+//!
+//! [`Severity`]: crate::codespan_reporting::Severity
+//!
+//! # Examples
+//!
+//! Sample usage can be seen in the repository [examples].
+//!
+//! [examples]: https://github.com/azriel91/srcerr/tree/main/examples
 
 pub use crate::model::{ErrorCode, ErrorDetail, SourceError};
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,6 +20,10 @@
 
 pub use crate::model::{ErrorCode, ErrorDetail, SourceError};
 
+// Re-export `codespan` so consumers don't have to depend on the crate directly.
+#[cfg(feature = "codespan")]
+pub use codespan;
+
 // Re-export `codespan_reporting` so consumers don't have to depend on the crate
 // directly.
 pub use codespan_reporting;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,7 +10,7 @@
 //!   variant contains information specific to an instance of the error.
 //! * [`Severity`]: The severity to report the error.
 //!
-//! [`Severity`]: crate::codespan_reporting::Severity
+//! [`Severity`]: codespan_reporting::diagnostic::Severity
 //!
 //! # Examples
 //!

--- a/src/model/error_detail.rs
+++ b/src/model/error_detail.rs
@@ -5,7 +5,7 @@ use codespan_reporting::{diagnostic::Label, files::Files};
 /// While [`ErrorCode`] represents a class of error, `ErrorDetail` captures the
 /// information for this specific instance of the error.
 ///
-/// [`ErrorCode`][crate::model::ErrorCode]
+/// [`ErrorCode`]: crate::ErrorCode
 pub trait ErrorDetail<'files> {
     /// Type of the collection of data that the error arises from.
     ///

--- a/src/model/source_error.rs
+++ b/src/model/source_error.rs
@@ -17,7 +17,7 @@ use crate::{
 /// * `E`: [`ErrorCode`][crate::ErrorCode] type.
 /// * `F`: [`Files`] referenced by this error.
 ///
-/// [`Files`][codespan_reporting::files::Files]
+/// [`Files`]: codespan_reporting::files::Files
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub struct SourceError<'files, Ec, Ed, Fs> {
     /// Code within the [`ErrorCode`] this error corresponds to.


### PR DESCRIPTION
### Added

* `"codespan"` feature to re-export [`codespan`] \(disabled by default\).

### Changed

* Update [`codespan-reporting`] version from `0.11.0` to `0.11.1`.
* Update documentation in `README.md` and `lib.rs`.

[`codespan`]: https://docs.rs/codespan
[`codespan-reporting`]: https://docs.rs/codespan-reporting